### PR TITLE
[refactor] Change data type from keywords to integers

### DIFF
--- a/src/advent/day_03/solution.clj
+++ b/src/advent/day_03/solution.clj
@@ -1,91 +1,41 @@
 (ns advent.day-03.solution
-  (:use [criterium.core])
+  (:use [criterium.core]
+        [clojure.pprint])
   (:require [support.reader :as r]
             [advent.day-03.transform :as t]))
-
-(def value->visited {:open :open-visited
-                     :tree :tree-visited})
 
 (defn movement-point
   [[x1 y1] [x2 y2]]
   [(+ x1 x2) (+ y1 y2)])
 
-(defn move
-  [chart point movement]
-  (let [movement-point (movement-point point movement)
-        value (get-in chart (reverse movement-point))
-        updated (assoc-in chart (reverse movement-point) (value->visited value))]
-    updated))
-
-(defn zip
-  [a b]
-  (loop [a a
-         b b
-         result []]
-    (if (empty? a)
-      result
-      (let [zipped (vec (concat (first a) (first b)))]
-        (recur (rest a) (rest b) (conj result zipped))))))
-
-(defn repeat-chart
-  [chart times]
-  (loop [t times
-         result chart]
-    (if (<= t 0)
-      result
-      (recur (dec t) (zip result chart)))))
-
-(defn repeat-how-many-times
-  [chart movement]
-  (let [chart-width (count (first chart))
-        chart-height (count chart)
-        [x _] movement
-        required-width (* (inc chart-height) x)
-        repeat-times (int (Math/ceil (/ required-width chart-width)))]
-    repeat-times))
-
-(defn outside-chart?
-  [width height [x y]]
-  (not (and (>= (dec width) x 0) (>= (dec height) y 0))))
-
-(defn amount-of-trees
-  [chart]
-  (reduce (fn [acc v]
-            (let [freq (frequencies v)
-                  trees-visited (:tree-visited freq 0)
-                  result (+ acc trees-visited)]
-              result)) 0 chart))
-
-(defn solve
+(defn solve-one
   [starting-point movement chart]
-  (let [repeat-chart-times (repeat-how-many-times chart movement)
-        repeated-chart (repeat-chart chart repeat-chart-times)
-        width (count (first repeated-chart))
-        height (count repeated-chart)]
+  (let [width (count (first chart))
+        height (count chart)]
     (loop [point starting-point
-           current-chart repeated-chart]
-      (let [updated-point (movement-point point movement)
-            outside? (outside-chart? width height updated-point)]
-        (if outside?
-          (amount-of-trees current-chart)
-          (let [updated-chart (move current-chart point movement)]
-            (recur updated-point updated-chart)))))))
+           result 0]
+      (let [next-point (movement-point point movement)
+            [x y] next-point
+            x (mod x width)
+            continue? (>= (dec height) y 0)]
+        (if continue?
+          (let [value (get-in chart [y x])]
+            (recur next-point (+ result value)))
+          result)))))
 
-(defn solve-first
-  [starting-point movement chart]
-  (solve starting-point movement chart))
-
-(defn solve-second
-  [starting-point movements chart]
+(defn solve-multiple
+  [starting-point chart movements]
   (reduce (fn [acc movement]
-            (let [b (solve starting-point movement chart)]
+            (let [b (solve-one starting-point movement chart)]
               (* acc b))) 1 movements))
 
 ;(def chart (->> (r/read-file-as-vec "input.txt") (t/transform)))
+;(def starting-point [0 0])
 
-;(println (solve-first [0 0] [3 1] chart))                   ; 156
-;(println (solve-second [0 0] [[1 1] [3 1] [5 1] [7 1] [1 2]] chart)) ; 3521829480
+;(def solve (partial solve-multiple starting-point chart))
 
-;(bench (solve-first [0 0] [3 1] chart))                     ; Execution time mean : 122 ms
-;(bench (solve-second [0 0] [[1 1] [3 1] [5 1] [7 1] [1 2]] chart)) ; Execution time mean : 1 sec
+;(println (solve [[3 1]]))                                   ; 156
+;(println (solve [[1 1] [3 1] [5 1] [7 1] [1 2]]))           ; 3521829480
 
+;(bench (solve [[3 1]]))                                     ; Execution time mean : 81 µs
+;(bench (solve [[1 1] [3 1] [5 1] [7 1] [1 2]]))             ; Execution time mean : 366 µs

--- a/src/advent/day_03/transform.clj
+++ b/src/advent/day_03/transform.clj
@@ -1,14 +1,14 @@
 (ns advent.day-03.transform)
 
-(def char->keyword {\. :open
-                    \# :tree})
+(def char->integer {\. 0
+                    \# 1})
 
-(defn row->values
+(defn row->integers
   [row]
-  (->> row (map char->keyword) vec))
+  (->> row (map char->integer) vec))
 
 (defn transform
   [data]
   (->> data
-       (map row->values)
+       (map row->integers)
        vec))

--- a/test/advent/day_03/solution_test.clj
+++ b/test/advent/day_03/solution_test.clj
@@ -17,11 +17,7 @@
 
 (def example-chart (t/transform example-input))
 
-(deftest solve-first-test
+(deftest solve-multiple-test
   (testing "given example input, should return example result"
-    (is (= 7 (solve-first [0 0] [3 1] example-chart)))))
-
-(deftest solve-second-test
-  (testing "given example inputs, should return example result"
-    (is (= 336 (solve-second [0 0] [[1 1] [3 1] [5 1] [7 1] [1 2]] example-chart)))))
-
+    (is (= 7 (solve-multiple [0 0] example-chart [[3 1]])))
+    (is (= 336 (solve-multiple [0 0] example-chart [[1 1] [3 1] [5 1] [7 1] [1 2]])))))

--- a/test/advent/day_03/transform_test.clj
+++ b/test/advent/day_03/transform_test.clj
@@ -4,9 +4,9 @@
 
 (deftest transform-test
   (testing "given a sequence of strings, should convert into multidimensional vector of keywords"
-    (is (= [[:open :tree]
-            [:tree :open]] (transform [".#" "#."])))
-    (is (= [[:open :tree :open :open]
-            [:tree :tree :open :open]
-            [:open :open :open :open]
-            [:tree :tree :tree :tree]] (transform [".#.." "##.." "...." "####"])))))
+    (is (= [[0 1]
+            [1 0]] (transform [".#" "#."])))
+    (is (= [[0 1 0 0]
+            [1 1 0 0]
+            [0 0 0 0]
+            [1 1 1 1]] (transform [".#.." "##.." "...." "####"])))))


### PR DESCRIPTION
Change the data type from keywords to integers to enable simple
calculations instead of funky conversions. Also, instead of creating
a proper y-repeated multidimensional array, use virtual array which
gets crawled. X-coordinates are calculated with help of modulus.